### PR TITLE
Make the package installable

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,0 @@
-PyVISA~=1.14.1
-nidaqmx~=1.0.2
-numpy~=2.2.1
-matplotlib~=3.10.0
-pythonnet~=3.0.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[project]
+name = "santec-il-sts"
+version = "2.8.8"
+description = "Program to measure Insertion Loss using the Santec's Swept Test System. "
+authors = [{ name = "Santec Corporation" }]
+license = { file = "LICENSE" }
+classifiers = [
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: Microsoft :: Windows",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
+]
+readme = "docs/README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "PyVISA>=1.14.1,<1.15.0",
+    "nidaqmx>=1.0.2,<1.1.0",
+    "numpy>=2.2.1,<2.3.0",
+    "matplotlib>=3.10.0,<3.11.0",
+    "pythonnet>=3.0.5,<3.1.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/santec"]
+
+[tool.hatch.build]
+exclude = ["src/santec/DLL/README.md"]


### PR DESCRIPTION
This is a super basic version of `pyproject.toml` which makes `santec-il-sts` installable as a python package (using `uv` in my case).
If this PR gets merged, other projects can depend on `santec-il-sts` as dependency directly from git. Here's how relevant section of their `pyproject.toml` would look like:
```
[project]
dependencies = [
    "santec-il-sts",
]

[tool.uv.sources]
santec-il-sts = { git = "https://github.com/santec-corporation/Python-IL-STS.git" }
```
With not much more effort (I think), you could push your package to `PyPI` and make the installation story even cleaner.